### PR TITLE
Various executor and context representation fixes

### DIFF
--- a/fixtures/data/wikitables/tables/346.tagged
+++ b/fixtures/data/wikitables/tables/346.tagged
@@ -1,0 +1,78 @@
+row	col	id	content	tokens	lemmaTokens	posTags	nerTags	nerValues	number	date	num2	list	listId
+-1	0	fb:row.row.null	#	#	#	#	O						
+-1	1	fb:row.row.date	Date	date	date	NN	O						
+-1	2	fb:row.row.venue	Venue	venue	venue	NN	O						
+-1	3	fb:row.row.opponent	Opponent	opponent	opponent	NN	O						
+-1	4	fb:row.row.result	Result	result	result	NN	O						
+-1	5	fb:row.row.competition	Competition	competition	competition	NN	O						
+-1	6	fb:row.row.scored	Scored	scored	score	VBN	O						
+0	0	fb:cell.1	1	1	1	CD	NUMBER	1.0	1.0				
+0	1	fb:cell.5_march_2002	5 March 2002	5|march|2002	5|March|2002	CD|NNP|CD	DATE|DATE|DATE	2002-03-05|2002-03-05|2002-03-05	5.0	2002-03-05	2002.0		
+0	2	fb:cell.lagos	Lagos	lagos	Lagos	NNP	LOCATION					Lagos	fb:part.lagos
+0	3	fb:cell.sweden	Sweden	sweden	Sweden	NNP	LOCATION						
+0	4	fb:cell.3_6	3–6	3|--|6	3|--|6	CD|:|CD	NUMBER|O|NUMBER	3.0||6.0	3.0		6.0		
+0	5	fb:cell.algarve_cup	Algarve Cup	algarve|cup	Algarve|Cup	NNP|NNP	MISC|MISC	|					
+0	6	fb:cell.1	1	1	1	CD	NUMBER	1.0	1.0				
+1	0	fb:cell.2	2	2	2	CD	NUMBER	2.0	2.0				
+1	1	fb:cell.22_september_2002	22 September 2002	22|september|2002	22|September|2002	CD|NNP|CD	DATE|DATE|DATE	2002-09-22|2002-09-22|2002-09-22	22.0	2002-09-22	2002.0		
+1	2	fb:cell.st_andrew_s_birmingham	St Andrew's, Birmingham	st|andrew|'s|,|birmingham	St|Andrew|'s|,|Birmingham	NNP|NNP|POS|,|NNP	PERSON|PERSON|O|O|LOCATION	||||				St Andrew's|Birmingham	fb:part.st_andrew_s|fb:part.birmingham
+1	3	fb:cell.iceland	Iceland	iceland	Iceland	NNP	LOCATION						
+1	4	fb:cell.1_0	1–0	1|--|0	1|--|0	CD|:|CD	NUMBER|O|NUMBER	1.0||0.0	1.0		0.0		
+1	5	fb:cell.2003_fifa_world_cup_qual	2003 FIFA World Cup Qual.	2003|fifa|world|cup|qual|.	2003|FIFA|World|Cup|Qual|.	CD|NNP|NNP|NNP|NNP|.	DATE|ORGANIZATION|O|O|O|O	2003|||||	2003.0				
+1	6	fb:cell.1	1	1	1	CD	NUMBER	1.0	1.0				
+2	0	fb:cell.3	3	3	3	CD	NUMBER	3.0	3.0				
+2	1	fb:cell.21_october_2003	21 October 2003	21|october|2003	21|October|2003	CD|NNP|CD	DATE|DATE|DATE	2003-10-21|2003-10-21|2003-10-21	21.0	2003-10-21	2003.0		
+2	2	fb:cell.kryoia_soveto_moscow	Kryoia Soveto, Moscow	kryoia|soveto|,|moscow	Kryoia|Soveto|,|Moscow	NNP|NNP|,|NNP	PERSON|PERSON|O|LOCATION	|||				Kryoia Soveto|Moscow	fb:part.kryoia_soveto|fb:part.moscow
+2	3	fb:cell.russia	Russia	russia	Russia	NNP	LOCATION						
+2	4	fb:cell.2_2	2–2	2|--|2	2|--|2	CD|:|CD	NUMBER|O|NUMBER	2.0||2.0	2.0		2.0		
+2	5	fb:cell.friendly	Friendly	friendly	friendly	JJ	O						
+2	6	fb:cell.1	1	1	1	CD	NUMBER	1.0	1.0				
+3	0	fb:cell.4	4	4	4	CD	NUMBER	4.0	4.0				
+3	1	fb:cell.14_november_2003	14 November 2003	14|november|2003	14|November|2003	CD|NNP|CD	DATE|DATE|DATE	2003-11-14|2003-11-14|2003-11-14	14.0	2003-11-14	2003.0		
+3	2	fb:cell.deepdale_preston	Deepdale, Preston	deepdale|,|preston	Deepdale|,|Preston	NNP|,|NNP	O|O|PERSON	||				Deepdale|Preston	fb:part.deepdale|fb:part.preston
+3	3	fb:cell.scotland	Scotland	scotland	Scotland	NNP	LOCATION						
+3	4	fb:cell.5_0	5–0	5|--|0	5|--|0	CD|:|CD	NUMBER|O|NUMBER	5.0||0.0	5.0		0.0		
+3	5	fb:cell.friendly	Friendly	friendly	friendly	JJ	O						
+3	6	fb:cell.1	1	1	1	CD	NUMBER	1.0	1.0				
+4	0	fb:cell.5	5	5	5	CD	NUMBER	5.0	5.0				
+4	1	fb:cell.16_september_2004	16 September 2004	16|september|2004	16|September|2004	CD|NNP|CD	DATE|DATE|DATE	2004-09-16|2004-09-16|2004-09-16	16.0	2004-09-16	2004.0		
+4	2	fb:cell.sportpark_de_wending_heerhugowaard	Sportpark De Wending, Heerhugowaard	sportpark|de|wending|,|heerhugowaard	Sportpark|De|Wending|,|Heerhugowaard	NNP|NNP|NNP|,|NNP	O|O|O|O|PERSON	||||				Sportpark De Wending|Heerhugowaard	fb:part.sportpark_de_wending|fb:part.heerhugowaard
+4	3	fb:cell.netherlands	Netherlands	netherlands	Netherlands	NNP	LOCATION						
+4	4	fb:cell.2_1	2–1	2|--|1	2|--|1	CD|:|CD	NUMBER|O|NUMBER	2.0||1.0	2.0		1.0		
+4	5	fb:cell.friendly	Friendly	friendly	friendly	JJ	O						
+4	6	fb:cell.1	1	1	1	CD	NUMBER	1.0	1.0				
+5	0	fb:cell.6	6	6	6	CD	NUMBER	6.0	6.0				
+5	1	fb:cell.17_february_2005	17 February 2005	17|february|2005	17|February|2005	CD|NNP|CD	DATE|DATE|DATE	2005-02-17|2005-02-17|2005-02-17	17.0	2005-02-17	2005.0		
+5	2	fb:cell.national_hockey_stadium_milton_keynes	National Hockey Stadium, Milton Keynes	national|hockey|stadium|,|milton|keynes	National|hockey|stadium|,|Milton|Keynes	NNP|NN|NN|,|NNP|NNP	O|O|O|O|PERSON|PERSON	|||||				National Hockey Stadium|Milton Keynes	fb:part.national_hockey_stadium|fb:part.milton_keynes
+5	3	fb:cell.italy	Italy	italy	Italy	NNP	LOCATION						
+5	4	fb:cell.4_1	4–1	4|--|1	4|--|1	CD|:|CD	NUMBER|O|NUMBER	4.0||1.0	4.0		1.0		
+5	5	fb:cell.friendly	Friendly	friendly	friendly	JJ	O						
+5	6	fb:cell.1	1	1	1	CD	NUMBER	1.0	1.0				
+6	0	fb:cell.7	7	7	7	CD	NUMBER	7.0	7.0				
+6	1	fb:cell.9_march_2005	9 March 2005	9|march|2005	9|March|2005	CD|NNP|CD	DATE|DATE|DATE	2005-03-09|2005-03-09|2005-03-09	9.0	2005-03-09	2005.0		
+6	2	fb:cell.faro	Faro	faro	Faro	NNP	PERSON					Faro	fb:part.faro
+6	3	fb:cell.portugal	Portugal	portugal	Portugal	NNP	LOCATION						
+6	4	fb:cell.4_0	4–0	4|--|0	4|--|0	CD|:|CD	NUMBER|O|NUMBER	4.0||0.0	4.0		0.0		
+6	5	fb:cell.algarve_cup	Algarve Cup	algarve|cup	Algarve|Cup	NNP|NNP	MISC|MISC	|					
+6	6	fb:cell.1	1	1	1	CD	NUMBER	1.0	1.0				
+7	0	fb:cell.8	8	8	8	CD	NUMBER	8.0	8.0				
+7	1	fb:cell.21_april_2005	21 April 2005	21|april|2005	21|April|2005	CD|NNP|CD	DATE|DATE|DATE	2005-04-21|2005-04-21|2005-04-21	21.0	2005-04-21	2005.0		
+7	2	fb:cell.prenton_park_tranmere	Prenton Park, Tranmere	prenton|park|,|tranmere	Prenton|Park|,|Tranmere	NNP|NNP|,|NNP	O|O|O|ORGANIZATION	|||				Prenton Park|Tranmere	fb:part.prenton_park|fb:part.tranmere
+7	3	fb:cell.scotland	Scotland	scotland	Scotland	NNP	LOCATION						
+7	4	fb:cell.2_1	2–1	2|--|1	2|--|1	CD|:|CD	NUMBER|O|NUMBER	2.0||1.0	2.0		1.0		
+7	5	fb:cell.friendly	Friendly	friendly	friendly	JJ	O						
+7	6	fb:cell.1	1	1	1	CD	NUMBER	1.0	1.0				
+8	0	fb:cell.9	9	9	9	CD	NUMBER	9.0	9.0				
+8	1	fb:cell.5_june_2005	5 June 2005	5|june|2005	5|June|2005	CD|NNP|CD	DATE|DATE|DATE	2005-06-05|2005-06-05|2005-06-05	5.0	2005-06-05	2005.0		
+8	2	fb:cell.city_of_manchester_stadium_manchester	City of Manchester Stadium, Manchester	city|of|manchester|stadium|,|manchester	City|of|Manchester|Stadium|,|Manchester	NNP|IN|NNP|NNP|,|NNP	O|O|LOCATION|LOCATION|O|LOCATION	|||||				City of Manchester Stadium|Manchester	fb:part.city_of_manchester_stadium|fb:part.manchester
+8	3	fb:cell.finland	Finland	finland	Finland	NNP	LOCATION						
+8	4	fb:cell.3_2	3–2	3|--|2	3|--|2	CD|:|CD	NUMBER|O|NUMBER	3.0||2.0	3.0		2.0		
+8	5	fb:cell.2005_uefa_championship	2005 UEFA Championship	2005|uefa|championship	2005|UEFA|Championship	CD|NNP|NNP	DATE|MISC|MISC	2005||	2005.0				
+8	6	fb:cell.1	1	1	1	CD	NUMBER	1.0	1.0				
+9	0	fb:cell.10	10	10	10	CD	NUMBER	10.0	10.0				
+9	1	fb:cell.1_september_2005	1 September 2005	1|september|2005	1|September|2005	CD|NNP|CD	DATE|DATE|DATE	2005-09-01|2005-09-01|2005-09-01	1.0	2005-09-01	2005.0		
+9	2	fb:cell.ertl_glas_stadion_amstetten	Ertl-Glas-Stadion, Amstetten	ertl|glas|stadion|,|amstetten	Ertl|Glas|Stadion|,|Amstetten	NNP|NNP|NNP|,|NNP	O|O|O|O|LOCATION	||||				Ertl-Glas-Stadion|Amstetten	fb:part.ertl_glas_stadion|fb:part.amstetten
+9	3	fb:cell.austria	Austria	austria	Austria	NNP	LOCATION						
+9	4	fb:cell.4_1	4–1	4|--|1	4|--|1	CD|:|CD	NUMBER|O|NUMBER	4.0||1.0	4.0		1.0		
+9	5	fb:cell.2007_fifa_world_cup_qual	2007 FIFA World Cup Qual.	2007|fifa|world|cup|qual|.	2007|FIFA|World|Cup|Qual|.	CD|NNP|NNP|NNP|NNP|.	DATE|MISC|MISC|MISC|O|O	2007|||||	2007.0				
+9	6	fb:cell.1	1	1	1	CD	NUMBER	1.0	1.0				

--- a/fixtures/data/wikitables/tables/654.tagged
+++ b/fixtures/data/wikitables/tables/654.tagged
@@ -1,0 +1,127 @@
+row	col	id	content	tokens	lemmaTokens	posTags	nerTags	nerValues	number	date	num2	list	listId
+-1	0	fb:row.row.year	Year	year	year	NN	DURATION						
+-1	1	fb:row.row.song	Song	song	song	NN	O						
+-1	2	fb:row.row.u_s	U.S.	u.s.	U.S.	NNP	LOCATION						
+-1	3	fb:row.row.u_s_r_b	U.S.\nR&B	u.s.|r&b	U.S.|r&b	NNP|NN	LOCATION|O	|					
+-1	4	fb:row.row.u_s_ac	U.S.\nAC	u.s.|ac	U.S.|ac	NNP|NN	LOCATION|O	|					
+-1	5	fb:row.row.uk	UK	uk	UK	NNP	LOCATION						
+-1	6	fb:row.row.album	Album	album	album	NN	O						
+0	0	fb:cell.1986	1986	1986	1986	CD	DATE	1986	1986.0	1986-xx-xx			
+0	1	fb:cell._strollin_on	"Strollin' On"	``|strollin|'|on|''	``|strollin|'|on|''	``|NN|''|IN|''	O|O|O|O|O	||||					
+0	2	fb:cell.null	-	-	-	:	O						
+0	3	fb:cell.null	-	-	-	:	O						
+0	4	fb:cell.null	-	-	-	:	O						
+0	5	fb:cell.32	32	32	32	CD	NUMBER	32.0	32.0				
+0	6	fb:cell.intentions	Intentions	intentions	intention	NNS	O						
+1	0	fb:cell.1986	1986	1986	1986	CD	DATE	1986	1986.0	1986-xx-xx			
+1	1	fb:cell._in_the_springtime	"In the Springtime"	``|in|the|springtime|''	``|in|the|Springtime|''	``|IN|DT|NNP|''	O|O|O|O|O	||||					
+1	2	fb:cell.null	-	-	-	:	O						
+1	3	fb:cell.null	-	-	-	:	O						
+1	4	fb:cell.null	-	-	-	:	O						
+1	5	fb:cell.54	54	54	54	CD	NUMBER	54.0	54.0				
+1	6	fb:cell.you_re_safe	You're Safe	you|'re|safe	you|be|safe	PRP|VBP|NN	O|O|O	||					
+2	0	fb:cell.1986	1986	1986	1986	CD	DATE	1986	1986.0	1986-xx-xx			
+2	1	fb:cell._crazy_love	"Crazy Love"	``|crazy|love|''	``|Crazy|Love|''	``|NNP|NNP|''	O|O|O|O	|||					
+2	2	fb:cell.null	-	-	-	:	O						
+2	3	fb:cell.null	-	-	-	:	O						
+2	4	fb:cell.null	-	-	-	:	O						
+2	5	fb:cell.67	67	67	67	CD	NUMBER	67.0	67.0				
+2	6	fb:cell.intentions	Intentions	intentions	intention	NNS	O						
+3	0	fb:cell.1987	1987	1987	1987	CD	DATE	1987	1987.0	1987-xx-xx			
+3	1	fb:cell._let_me_know	"Let Me Know"	``|let|me|know|''	``|let|I|Know|''	``|VB|PRP|NNP|''	O|O|O|O|O	||||					
+3	2	fb:cell.null	-	-	-	:	O						
+3	3	fb:cell.null	-	-	-	:	O						
+3	4	fb:cell.null	-	-	-	:	O						
+3	5	fb:cell.49	49	49	49	CD	NUMBER	49.0	49.0				
+3	6	fb:cell.intentions	Intentions	intentions	intention	NNS	O						
+4	0	fb:cell.1987	1987	1987	1987	CD	DATE	1987	1987.0	1987-xx-xx			
+4	1	fb:cell._woman_in_you	"Woman in You"	``|woman|in|you|''	``|Woman|in|you|''	``|NNP|IN|PRP|''	O|O|O|O|O	||||					
+4	2	fb:cell.null	-	-	-	:	O						
+4	3	fb:cell.null	-	-	-	:	O						
+4	4	fb:cell.null	-	-	-	:	O						
+4	5	fb:cell.null	-	-	-	:	O						
+4	6	fb:cell.intentions	Intentions	intentions	intention	NNS	O						
+5	0	fb:cell.1987	1987	1987	1987	CD	DATE	1987	1987.0	1987-xx-xx			
+5	1	fb:cell._some_guys_have_all_the_luck	"Some Guys Have All the Luck"	``|some|guys|have|all|the|luck|''	``|some|Guys|have|all|the|Luck|''	``|DT|NNP|VBD-AUX|PDT|DT|NNP|''	O|O|O|O|O|O|O|O	|||||||					
+5	2	fb:cell.null	-	-	-	:	O						
+5	3	fb:cell.null	-	-	-	:	O						
+5	4	fb:cell.null	-	-	-	:	O						
+5	5	fb:cell.12	12	12	12	CD	NUMBER	12.0	12.0				
+5	6	fb:cell.null_2											
+6	0	fb:cell.1989	1989	1989	1989	CD	DATE	1989	1989.0	1989-xx-xx			
+6	1	fb:cell._wild_world	"Wild World"	``|wild|world|''	``|Wild|World|''	``|NNP|NNP|''	O|O|O|O	|||					
+6	2	fb:cell.25	25	25	25	CD	NUMBER	25.0	25.0				
+6	3	fb:cell.null	-	-	-	:	O						
+6	4	fb:cell.null	-	-	-	:	O						
+6	5	fb:cell.5	5	5	5	CD	NUMBER	5.0	5.0				
+6	6	fb:cell.maxi_priest	Maxi Priest	maxi|priest	Maxi|Priest	NNP|NNP	O|O	|					
+7	0	fb:cell.1990	1990	1990	1990	CD	DATE	1990	1990.0	1990-xx-xx			
+7	1	fb:cell._human_work_of_art	"Human Work of Art"	``|human|work|of|art|''	``|human|work|of|Art|''	``|JJ|NN|IN|NNP|''	O|O|O|O|O|O	|||||					
+7	2	fb:cell.null	-	-	-	:	O						
+7	3	fb:cell.null	-	-	-	:	O						
+7	4	fb:cell.null	-	-	-	:	O						
+7	5	fb:cell.71	71	71	71	CD	NUMBER	71.0	71.0				
+7	6	fb:cell.bonafide	Bonafide	bonafide	Bonafide	NNP	O						
+8	0	fb:cell.1990	1990	1990	1990	CD	DATE	1990	1990.0	1990-xx-xx			
+8	1	fb:cell._close_to_you	"Close to You"	``|close|to|you|''	``|close|to|you|''	``|VB|TO|PRP|''	O|O|O|O|O	||||					
+8	2	fb:cell.1	1	1	1	CD	NUMBER	1.0	1.0				
+8	3	fb:cell.2	2	2	2	CD	NUMBER	2.0	2.0				
+8	4	fb:cell.15	15	15	15	CD	NUMBER	15.0	15.0				
+8	5	fb:cell.7	7	7	7	CD	NUMBER	7.0	7.0				
+8	6	fb:cell.bonafide	Bonafide	bonafide	Bonafide	NNP	O						
+9	0	fb:cell.1990	1990	1990	1990	CD	DATE	1990	1990.0	1990-xx-xx			
+9	1	fb:cell._just_a_little_bit_longer	"Just a Little Bit Longer"	``|just|a|little|bit|longer|''	``|just|a|little|bit|longer|''	``|RB|DT|JJ|NN|JJR|''	O|O|O|O|O|O|O	||||||					
+9	2	fb:cell.62	62	62	62	CD	NUMBER	62.0	62.0				
+9	3	fb:cell.30	30	30	30	CD	NUMBER	30.0	30.0				
+9	4	fb:cell.null	-	-	-	:	O						
+9	5	fb:cell.62	62	62	62	CD	NUMBER	62.0	62.0				
+9	6	fb:cell.bonafide	Bonafide	bonafide	Bonafide	NNP	O						
+10	0	fb:cell.1991	1991	1991	1991	CD	DATE	1991	1991.0	1991-xx-xx			
+10	1	fb:cell._space_in_my_heart	"Space in My Heart"	``|space|in|my|heart|''	``|space|in|my|Heart|''	``|NN|IN|PRP$|NNP|''	O|O|O|O|O|O	|||||					
+10	2	fb:cell.null	-	-	-	:	O						
+10	3	fb:cell.76	76	76	76	CD	NUMBER	76.0	76.0				
+10	4	fb:cell.null	-	-	-	:	O						
+10	5	fb:cell.null	-	-	-	:	O						
+10	6	fb:cell.bonafide	Bonafide	bonafide	Bonafide	NNP	O						
+11	0	fb:cell.1991	1991	1991	1991	CD	DATE	1991	1991.0	1991-xx-xx			
+11	1	fb:cell._set_the_night_to_music_with_roberta_flack	"Set the Night to Music" (with Roberta Flack)	``|set|the|night|to|music|''|-lrb-|with|roberta|flack|-rrb-	``|set|the|night|to|Music|''|-lrb-|with|Roberta|Flack|-rrb-	``|VB|DT|NN|TO|NNP|''|-LRB-|IN|NNP|NNP|-RRB-	O|O|O|TIME|MISC|MISC|O|O|O|PERSON|PERSON|O	|||TNI||||||||					
+11	2	fb:cell.6	6	6	6	CD	NUMBER	6.0	6.0				
+11	3	fb:cell.45	45	45	45	CD	NUMBER	45.0	45.0				
+11	4	fb:cell.2	2	2	2	CD	NUMBER	2.0	2.0				
+11	5	fb:cell.null	-	-	-	:	O						
+11	6	fb:cell.set_the_night_to_music_roberta_flack	Set the Night to Music (Roberta Flack)	set|the|night|to|music|-lrb-|roberta|flack|-rrb-	set|the|night|to|music|-lrb-|Roberta|Flack|-rrb-	VB|DT|NN|TO|NN|-LRB-|NNP|NNP|-RRB-	O|O|TIME|MISC|MISC|O|PERSON|PERSON|O	||TNI||||||					
+12	0	fb:cell.1992	1992	1992	1992	CD	DATE	1992	1992.0	1992-xx-xx			
+12	1	fb:cell._groovin_in_the_midnight	"Groovin' in the Midnight"	``|groovin|'|in|the|midnight|''	``|groovin|'|in|the|midnight|''	``|NN|''|IN|DT|NN|''	O|O|O|O|O|TIME|O	|||||T00:00|					
+12	2	fb:cell.63	63	63	63	CD	NUMBER	63.0	63.0				
+12	3	fb:cell.29	29	29	29	CD	NUMBER	29.0	29.0				
+12	4	fb:cell.null	-	-	-	:	O						
+12	5	fb:cell.50	50	50	50	CD	NUMBER	50.0	50.0				
+12	6	fb:cell.fe_real	Fe Real	fe|real	Fe|Real	NNP|NNP	O|O	|					
+13	0	fb:cell.1993	1993	1993	1993	CD	DATE	1993	1993.0	1993-xx-xx			
+13	1	fb:cell._one_more_chance	"One More Chance"	``|one|more|chance|''	``|one|more|chance|''	``|CD|JJR|NN|''	O|NUMBER|O|O|O	|1.0|||					
+13	2	fb:cell.null	-	-	-	:	O						
+13	3	fb:cell.77	77	77	77	CD	NUMBER	77.0	77.0				
+13	4	fb:cell.null	-	-	-	:	O						
+13	5	fb:cell.40	40	40	40	CD	NUMBER	40.0	40.0				
+13	6	fb:cell.fe_real	Fe Real	fe|real	Fe|Real	NNP|NNP	O|O	|					
+14	0	fb:cell.1996	1996	1996	1996	CD	DATE	1996	1996.0	1996-xx-xx			
+14	1	fb:cell._that_girl_with_shaggy	"That Girl" (with Shaggy)	``|that|girl|''|-lrb-|with|shaggy|-rrb-	``|that|Girl|''|-lrb-|with|shaggy|-rrb-	``|DT|NNP|''|-LRB-|IN|NN|-RRB-	O|O|O|O|O|O|O|O	|||||||					
+14	2	fb:cell.20	20	20	20	CD	NUMBER	20.0	20.0				
+14	3	fb:cell.34	34	34	34	CD	NUMBER	34.0	34.0				
+14	4	fb:cell.null	-	-	-	:	O						
+14	5	fb:cell.15	15	15	15	CD	NUMBER	15.0	15.0				
+14	6	fb:cell.man_with_the_fun	Man with the Fun	man|with|the|fun	man|with|the|fun	NN|IN|DT|NN	O|O|O|O	|||					
+15	0	fb:cell.1996	1996	1996	1996	CD	DATE	1996	1996.0	1996-xx-xx			
+15	1	fb:cell._watching_the_world_go_by	"Watching the World Go By"	``|watching|the|world|go|by|''	``|watch|the|World|go|by|''	``|VBG|DT|NNP|VB|IN|''	O|O|O|O|O|O|O	||||||					
+15	2	fb:cell.null	-	-	-	:	O						
+15	3	fb:cell.null	-	-	-	:	O						
+15	4	fb:cell.null	-	-	-	:	O						
+15	5	fb:cell.36	36	36	36	CD	NUMBER	36.0	36.0				
+15	6	fb:cell.man_with_the_fun	Man with the Fun	man|with|the|fun	man|with|the|fun	NN|IN|DT|NN	O|O|O|O	|||					
+16	0	fb:cell.2009	2009	2009	2009	CD	DATE	2009	2009.0	2009-xx-xx			
+16	1	fb:cell._2_play_feat_maxi_priest_that_s_what_the_girls_like_sam_young_jack_black_mix	"2 Play feat Maxi Priest - That's what the girls like (Sam Young & Jack Black Mix)"	``|2|play|feat|maxi|priest|-|that|'s|what|the|girls|like|-lrb-|sam|young|&|jack|black|mix|-rrb-|''	``|2|Play|feat|Maxi|Priest|-|that|be|what|the|girl|like|-lrb-|Sam|Young|&|Jack|Black|Mix|-rrb-|''	``|CD|NNP|NN|NNP|NNP|:|WDT|VBZ|WP|DT|NNS|IN|-LRB-|NNP|NNP|CC|NNP|NNP|NNP|-RRB-|''	O|NUMBER|O|O|O|O|O|O|O|O|O|O|O|O|ORGANIZATION|ORGANIZATION|ORGANIZATION|ORGANIZATION|ORGANIZATION|ORGANIZATION|O|O	|2.0||||||||||||||||||||	2.0				
+16	2	fb:cell.null	-	-	-	:	O						
+16	3	fb:cell.null	-	-	-	:	O						
+16	4	fb:cell.null	-	-	-	:	O						
+16	5	fb:cell.null	-	-	-	:	O						
+16	6	fb:cell.null_2											

--- a/scripts/wikitables/search_for_logical_forms.py
+++ b/scripts/wikitables/search_for_logical_forms.py
@@ -5,9 +5,13 @@ import sys
 import os
 import argparse
 import gzip
+import logging
+import math
+from multiprocessing import Process
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(os.path.join(__file__, os.pardir)))))
 
+from allennlp.common.util import JsonDict
 from allennlp.data.tokenizers import WordTokenizer
 from allennlp.data.dataset_readers.semantic_parsing.wikitables import util as wikitables_util
 
@@ -16,14 +20,15 @@ from weak_supervision.semparse.worlds import WikiTablesVariableFreeWorld
 from weak_supervision.semparse import ActionSpaceWalker
 
 def search(tables_directory: str,
-           input_examples_file: str,
+           data: JsonDict,
            output_path: str,
            max_path_length: int,
            max_num_logical_forms: int,
            use_agenda: bool,
            output_separate_files: bool) -> None:
-    data = [wikitables_util.parse_example_line(example_line) for example_line in
-            open(input_examples_file)]
+    print(f"Starting search with {len(data)} instances", file=sys.stderr)
+    executor_logger = logging.getLogger('weak_supervision.semparse.executors.wikitables_variable_free_executor')
+    executor_logger.setLevel(logging.ERROR)
     tokenizer = WordTokenizer()
     if output_separate_files and not os.path.exists(output_path):
         os.makedirs(output_path)
@@ -88,6 +93,26 @@ if __name__ == "__main__":
                         action="store_true", help="""If set, the script will output gzipped
                         files, one per example. You may want to do this if you;re making data to
                         train a parser.""")
+    parser.add_argument("--num-splits", dest="num_splits", type=int, default=0,
+                        help="Number of splits to make of the data, to run as many processes (default 0)")
     args = parser.parse_args()
-    search(args.table_directory, args.data_file, args.output_path, args.max_path_length,
-           args.max_num_logical_forms, args.use_agenda, args.output_separate_files)
+    input_data = [wikitables_util.parse_example_line(example_line) for example_line in
+                  open(args.data_file)]
+    if args.num_splits == 0 or len(input_data) <= args.num_splits or not args.output_separate_files:
+        search(args.table_directory, input_data, args.output_path, args.max_path_length,
+               args.max_num_logical_forms, args.use_agenda, args.output_separate_files)
+    else:
+        chunk_size = math.ceil(len(input_data)/args.num_splits)
+        start_index = 0
+        for i in range(args.num_splits):
+            if i == args.num_splits - 1:
+                data_split = input_data[start_index:]
+            else:
+                data_split = input_data[start_index:start_index + chunk_size]
+            start_index += chunk_size
+            process = Process(target=search, args=(args.table_directory, data_split,
+                                                   args.output_path, args.max_path_length,
+                                                   args.max_num_logical_forms, args.use_agenda,
+                                                   args.output_separate_files))
+            print(f"Starting process {i}", file=sys.stderr)
+            process.start()

--- a/tests/semparse/contexts/table_question_context_test.py
+++ b/tests/semparse/contexts/table_question_context_test.py
@@ -55,6 +55,15 @@ class TestTableQuestionContext(AllenNlpTestCase):
         _, number_entities = table_question_context.get_entities_from_question()
         assert number_entities == [("191617", 5), ("100", 16)]
 
+    def test_number_extraction_with_decimals(self):
+        question = """how many players on the 191617 illinois fighting illini men's basketball team
+                      had more than 0.3 points scored?"""
+        question_tokens = self.tokenizer.tokenize(question)
+        test_file = f'{self.FIXTURES_ROOT}/data/corenlp_processed_tables/TEST-7.table'
+        table_question_context = TableQuestionContext.read_from_file(test_file, question_tokens)
+        _, number_entities = table_question_context.get_entities_from_question()
+        assert number_entities == [("191617", 5), ("0.3", 16)]
+
     def test_date_extraction(self):
         question = "how many laps did matt kenset complete on february 26, 2006."
         question_tokens = self.tokenizer.tokenize(question)
@@ -71,6 +80,14 @@ class TestTableQuestionContext(AllenNlpTestCase):
         table_question_context = TableQuestionContext.read_from_file(test_file, question_tokens)
         _, number_entities = table_question_context.get_entities_from_question()
         assert number_entities == [("1979", 12)]
+
+    def test_entity_extraction_from_question_with_quotes(self):
+        question = "how many times does \"friendly\" appear in the competition column?"
+        question_tokens = self.tokenizer.tokenize(question)
+        test_file = 'fixtures/data/wikitables/tables/346.tagged'
+        table_question_context = TableQuestionContext.read_from_file(test_file, question_tokens)
+        entities, _ = table_question_context.get_entities_from_question()
+        assert entities == [('string:friendly', 'string_column:competition')]
 
     def test_multiword_entity_extraction(self):
         question = "was the positioning better the year of the france venue or the year of the south korea venue?"

--- a/tests/semparse/contexts/table_question_context_test.py
+++ b/tests/semparse/contexts/table_question_context_test.py
@@ -87,7 +87,7 @@ class TestTableQuestionContext(AllenNlpTestCase):
         test_file = 'fixtures/data/wikitables/tables/346.tagged'
         table_question_context = TableQuestionContext.read_from_file(test_file, question_tokens)
         entities, _ = table_question_context.get_entities_from_question()
-        assert entities == [('string:friendly', 'string_column:competition')]
+        assert entities == [('string:friendly', ['string_column:competition'])]
 
     def test_multiword_entity_extraction(self):
         question = "was the positioning better the year of the france venue or the year of the south korea venue?"
@@ -95,8 +95,8 @@ class TestTableQuestionContext(AllenNlpTestCase):
         test_file = f'{self.FIXTURES_ROOT}/data/corenlp_processed_tables/TEST-3.table'
         table_question_context = TableQuestionContext.read_from_file(test_file, question_tokens)
         entities, _ = table_question_context.get_entities_from_question()
-        assert entities == [("string:france", "string_column:venue"),
-                            ("string:south_korea", "string_column:venue")]
+        assert entities == [("string:france", ["string_column:venue"]),
+                            ("string:south_korea", ["string_column:venue"])]
 
     def test_rank_number_extraction(self):
         question = "what was the first tamil-language film in 1943?"
@@ -162,8 +162,8 @@ class TestTableQuestionContext(AllenNlpTestCase):
         test_file = f"{self.FIXTURES_ROOT}/data/corenlp_processed_tables/TEST-11.table"
         table_question_context = TableQuestionContext.read_from_file(test_file, question_tokens)
         string_entities, number_entities = table_question_context.get_entities_from_question()
-        assert string_entities == [("string:m1", "string_column:notation"),
-                                   ("string:1", "string_column:position")]
+        assert string_entities == [("string:m1", ["string_column:notation"]),
+                                   ("string:1", ["string_column:position"])]
         assert number_entities == [("1", 2), ("1", 7)]
 
     def test_get_knowledge_graph(self):

--- a/tests/semparse/executors/wikitables_variable_free_executor_test.py
+++ b/tests/semparse/executors/wikitables_variable_free_executor_test.py
@@ -74,6 +74,11 @@ class TestWikiTablesVariableFreeExecutor(AllenNlpTestCase):
                                    all_rows) string_column:league)"""
         with self.assertRaises(ExecutionError):
             self.executor.execute(logical_form)
+        # Replacing the filter value with an invalid value.
+        logical_form = """(select_string (filter_number_greater all_rows number_column:avg_attendance
+                            string:usl_first_division) string_column:league)"""
+        with self.assertRaises(ExecutionError):
+            self.executor.execute(logical_form)
 
     def test_execute_works_with_filter_date_greater(self):
         # Selecting cell values from all rows that have date greater than 2002.
@@ -95,6 +100,11 @@ class TestWikiTablesVariableFreeExecutor(AllenNlpTestCase):
         assert count_result == [2.0]
         # Replacing the filter value with an invalid value.
         logical_form = """(count (filter_number_greater all_rows number_column:avg_attendance all_rows))"""
+        with self.assertRaises(ExecutionError):
+            self.executor.execute(logical_form)
+        # Replacing the filter value with an invalid value.
+        logical_form = """(count (filter_number_greater all_rows number_column:avg_attendance
+                                  string:usl_a_league))"""
         with self.assertRaises(ExecutionError):
             self.executor.execute(logical_form)
 
@@ -120,6 +130,11 @@ class TestWikiTablesVariableFreeExecutor(AllenNlpTestCase):
         # Replacing the filter value with an invalid value.
         logical_form = """(select_string (filter_number_lesser all_rows date_column:date
                                    (date 2005 -1 -1)) string_column:league)"""
+        with self.assertRaises(ExecutionError):
+            self.executor.execute(logical_form)
+        # Replacing the filter value with an invalid value.
+        logical_form = """(select_string (filter_number_lesser all_rows date_column:date
+                                          string:5th) string_column:league)"""
         with self.assertRaises(ExecutionError):
             self.executor.execute(logical_form)
 
@@ -222,6 +237,11 @@ class TestWikiTablesVariableFreeExecutor(AllenNlpTestCase):
                                    string_column:regular_season)"""
         cell_list = self.executor.execute(logical_form)
         assert cell_list == ["5th"]
+        # Replacing the filter value with an invalid value.
+        logical_form = """(select_string (filter_not_in all_rows string_column:open_cup 2000)
+                                   string_column:regular_season)"""
+        with self.assertRaises(ExecutionError):
+            self.executor.execute(logical_form)
 
     def test_execute_works_with_first(self):
         # Selecting "regular season" from the first row.

--- a/tests/semparse/worlds/wikitables_variable_free_world_test.py
+++ b/tests/semparse/worlds/wikitables_variable_free_world_test.py
@@ -5,7 +5,7 @@ from typing import List
 from functools import partial
 
 from allennlp.common.testing import AllenNlpTestCase
-from allennlp.data.tokenizers import Token, WordTokenizer
+from allennlp.data.tokenizers import Token
 from allennlp.semparse import ParsingError
 
 from weak_supervision.semparse.contexts import TableQuestionContext

--- a/tests/semparse/worlds/wikitables_variable_free_world_test.py
+++ b/tests/semparse/worlds/wikitables_variable_free_world_test.py
@@ -5,7 +5,7 @@ from typing import List
 from functools import partial
 
 from allennlp.common.testing import AllenNlpTestCase
-from allennlp.data.tokenizers import Token
+from allennlp.data.tokenizers import Token, WordTokenizer
 from allennlp.semparse import ParsingError
 
 from weak_supervision.semparse.contexts import TableQuestionContext

--- a/weak_supervision/data/dataset_readers/semantic_parsing/wikitables/util.py
+++ b/weak_supervision/data/dataset_readers/semantic_parsing/wikitables/util.py
@@ -87,6 +87,9 @@ def parse_example_line_with_labels(lisp_string: str) -> Dict:
         if string != "":
             target_values.append(string)
 
+    # This is to remove the escape characters (usually before quotes) that are already in the
+    # examples file. Not doing this may prevent some entities being extracted from the question.
+    question = question.replace("\\", "")
     return {'id': example_id,
             'question': question,
             'table_filename': table_filename,
@@ -113,6 +116,10 @@ def parse_example_line(lisp_string: str) -> Dict:
         string = string.replace(")", "").replace('"', '').strip()
         if string != "":
             target_values.append(string)
+
+    # This is to remove the escape characters (usually before quotes) that are already in the
+    # examples file. Not doing this may prevent some entities being extracted from the question.
+    question = question.replace("\\", "")
     return {'id': example_id,
             'question': question,
             'table_filename': table_filename,

--- a/weak_supervision/data/dataset_readers/semantic_parsing/wikitables/wikitables_variable_free.py
+++ b/weak_supervision/data/dataset_readers/semantic_parsing/wikitables/wikitables_variable_free.py
@@ -16,7 +16,6 @@ from allennlp.data.instance import Instance
 from allennlp.data.fields import (Field, TextField, MetadataField, ProductionRuleField,
                                   ListField, IndexField, KnowledgeGraphField)
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
-from allennlp.data.dataset_readers.semantic_parsing.wikitables import util as wikitables_util
 from allennlp.data.tokenizers import WordTokenizer
 from allennlp.data.tokenizers.tokenizer import Tokenizer
 from allennlp.data.tokenizers.word_splitter import SpacyWordSplitter
@@ -24,6 +23,7 @@ from allennlp.data.token_indexers import SingleIdTokenIndexer
 from allennlp.data.token_indexers.token_indexer import TokenIndexer
 from allennlp.semparse.worlds.world import ParsingError
 
+from weak_supervision.data.dataset_readers.semantic_parsing.wikitables import util as wikitables_util
 from weak_supervision.semparse.contexts import TableQuestionContext
 from weak_supervision.semparse.worlds import WikiTablesVariableFreeWorld
 

--- a/weak_supervision/semparse/contexts/table_question_context.py
+++ b/weak_supervision/semparse/contexts/table_question_context.py
@@ -1,6 +1,6 @@
 import re
 import csv
-from typing import Union, Dict, List, Optional, Tuple, Set
+from typing import Union, Dict, List, Tuple, Set
 from collections import defaultdict
 
 from unidecode import unidecode
@@ -211,10 +211,11 @@ class TableQuestionContext:
                 entity_text[typed_column_name] = typed_column_name.split(":")[-1].replace("_", " ")
 
             string_entities, numbers = self.get_entities_from_question()
-            for entity, column_name in string_entities:
+            for entity, column_names in string_entities:
                 entities.add(entity)
-                neighbors[entity].append(column_name)
-                neighbors[column_name].append(entity)
+                for column_name in column_names:
+                    neighbors[entity].append(column_name)
+                    neighbors[column_name].append(entity)
                 entity_text[entity] = entity.replace("string:", "").replace("_", " ")
             # For all numbers (except -1), we add all number and date columns as their neighbors.
             for number, _ in numbers:
@@ -330,21 +331,21 @@ class TableQuestionContext:
             normalized_token_text = self.normalize_string(token_text)
             if not normalized_token_text:
                 continue
-            token_column = self._string_in_table(normalized_token_text)
-            if token_column:
-                token_type = token_column.split(":")[0].replace("_column", "")
+            token_columns = self._string_in_table(normalized_token_text)
+            if token_columns:
+                token_type = token_columns[0].split(":")[0].replace("_column", "")
                 entity_data.append({'value': normalized_token_text,
                                     'token_start': i,
                                     'token_end': i+1,
                                     'token_type': token_type,
-                                    'token_in_column': token_column})
+                                    'token_in_columns': token_columns})
 
         extracted_numbers = self._get_numbers_from_tokens(self.question_tokens)
         # filter out number entities to avoid repetition
         expanded_entities = []
         for entity in self._expand_entities(self.question_tokens, entity_data):
             if entity["token_type"] == "string":
-                expanded_entities.append((f"string:{entity['value']}", entity['token_in_column']))
+                expanded_entities.append((f"string:{entity['value']}", entity['token_in_columns']))
         return expanded_entities, extracted_numbers  #TODO(shikhar) Handle conjunctions
 
     @staticmethod
@@ -415,10 +416,10 @@ class TableQuestionContext:
                     numbers.append((str(int(number + 10 ** num_zeros)), i))
         return numbers
 
-    def _string_in_table(self, candidate: str) -> Optional[str]:
+    def _string_in_table(self, candidate: str) -> List[str]:
         """
-        Checks if the string occurs in the table, and if it does, returns the name of the column
-        under which it occurs. If it does not, returns None.
+        Checks if the string occurs in the table, and if it does, returns the names of the columns
+        under which it occurs. If it does not, returns an empty list.
         """
         candidate_column_names: List[str] = []
         # First check if the entire candidate occurs as a cell.
@@ -428,15 +429,9 @@ class TableQuestionContext:
         if not candidate_column_names:
             for cell_value, column_names in self._string_column_mapping.items():
                 if candidate in cell_value:
-                    candidate_column_names = column_names
-                    break
-        if not candidate_column_names:
-            return None
+                    candidate_column_names.extend(column_names)
         candidate_column_names = list(set(candidate_column_names))
-        # Note: if candidate_column_names is now a list with more than one element, it means that
-        # the candidate matched a cell value that occurs under multiple columns. This is
-        # unusual, and we are ignoring such cases, and simply returning the first name.
-        return candidate_column_names[0]
+        return candidate_column_names
 
     def _process_conjunction(self, entity_data):
         raise NotImplementedError
@@ -451,7 +446,7 @@ class TableQuestionContext:
             current_end = entity['token_end']
             current_token = entity['value']
             current_token_type = entity['token_type']
-            current_token_column = entity['token_in_column']
+            current_token_columns = entity['token_in_columns']
 
             while current_end < len(question):
                 next_token = question[current_end].text
@@ -460,22 +455,22 @@ class TableQuestionContext:
                     current_end += 1
                     continue
                 candidate = "%s_%s" %(current_token, next_token_normalized)
-                candidate_column = self._string_in_table(candidate)
-                if candidate_column is None:
-                    candidate_type = None
-                else:
-                    candidate_type = candidate_column.split(":")[0].replace("_column", "")
-                if candidate_type is not None and candidate_type == current_token_type:
-                    current_end += 1
-                    current_token = candidate
-                else:
+                candidate_columns = self._string_in_table(candidate)
+                candidate_columns = list(set(candidate_columns).intersection(current_token_columns))
+                if not candidate_columns:
                     break
+                candidate_type = candidate_columns[0].split(":")[0].replace("_column", "")
+                if candidate_type != current_token_type:
+                    break
+                current_end += 1
+                current_token = candidate
+                current_token_columns = candidate_columns
 
             new_entities.append({'token_start' : current_start,
                                  'token_end' : current_end,
                                  'value' : current_token,
                                  'token_type': current_token_type,
-                                 'token_in_column': current_token_column})
+                                 'token_in_columns': current_token_columns})
         return new_entities
 
     @staticmethod

--- a/weak_supervision/semparse/contexts/table_question_context.py
+++ b/weak_supervision/semparse/contexts/table_question_context.py
@@ -384,20 +384,27 @@ class TableQuestionContext:
             # we'll take that risk.  It shouldn't be a big deal.
             text = ''.join(text[i] for i, char in enumerate(text) if char in NUMBER_CHARACTERS)
 
+            text_has_no_words = False
             try:
                 # We'll use a check for float(text) to find numbers, because text.isdigit() doesn't
                 # catch things like "-3" or "0.07".
                 number = float(text)
+                text_has_no_words = True
             except ValueError:
                 pass
 
             if number is not None:
-                number = number * magnitude
-                if '.' in text:
-                    number_string = '%.3f' % number
+                # If the text has words (e.g.: 1 million), we make a string from the number and add
+                # that to our list of numbers. Or else, we directly add the text itself.
+                if text_has_no_words:
+                    numbers.append((text, i))
                 else:
-                    number_string = '%d' % number
-                numbers.append((number_string, i))
+                    number = number * magnitude
+                    if '.' in text:
+                        number_string = '%.3f' % number
+                    else:
+                        number_string = '%d' % number
+                    numbers.append((number_string, i))
                 if is_range:
                     # TODO(mattg): both numbers in the range will have the same text, and so the
                     # linking score won't have any way to differentiate them...  We should figure

--- a/weak_supervision/semparse/executors/wikitables_variable_free_executor.py
+++ b/weak_supervision/semparse/executors/wikitables_variable_free_executor.py
@@ -782,6 +782,9 @@ class WikiTablesVariableFreeExecutor:
         most_frequent_list: List[str] = []
         for row in row_list:
             cell_value = row[column_name]
+            # Ignore if cell value is None or an empty string
+            if not cell_value:
+                continue
             value_frequencies[cell_value] += 1
             frequency = value_frequencies[cell_value]
             if frequency > max_frequency:


### PR DESCRIPTION
After these fixes only 8% of the logical forms produced by Chen's random exploration code cannot be executed by our executor. The unexecutable ones are related to discrepancies in how we deal with some edge cases in the logic (e.g.: how should filtering operations deal with empty cells). The logical forms are mostly spurious, and I don't think we need to cover them.

There are also some other untranslatable logical forms for various reasons, and on the whole we can use logical forms for 95% of the questions.